### PR TITLE
Support offset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ pip install pdfbookmarker
     <nested level>"<bookmark title>"|<page number>
     ```
 
-For samples, see `sample_bookmarks.txt`.
+For samples, see [`sample_bookmarks.txt`](./sample_bookmarks.txt).
 
 2)  Generate a copy of `MyBook.pdf` with additional bookmarks file specified by
     `my_bookmarks.txt`:

--- a/pdfbookmarker.py
+++ b/pdfbookmarker.py
@@ -117,13 +117,20 @@ def get_bookmarks_tree(bookmarks_filename):
     # `value`: the children list of the node
     latest_nodes = {0: tree}
 
+    offset = 0
     prev_level = 0
     for line in codecs.open(bookmarks_filename, 'r', encoding='utf-8'):
+        if line[0:2] == '//':
+            try:
+                offset = int(line[2:])
+            except ValueError:
+                pass
+            continue
         res = re.match(r'(\+*)\s*?"([^"]+)"\s*\|\s*(\d+)', line.strip())
         if res:
             pluses, title, page_num = res.groups()
             cur_level = len(pluses)  # plus count stands for level
-            cur_node = (title, int(page_num) - 1, [])
+            cur_node = (title, int(page_num) - 1 + offset, [])
 
             if not (0 < cur_level <= prev_level + 1):
                 raise Exception('plus (+) count is invalid here: %s' % line.strip())


### PR DESCRIPTION
The page numbers in a `toc.txt` file are usually different from those in the corresponding TOC pages.
Moreover, some PDF generators delete blank pages, which makes the page-number mapping more complicated.
Adding the offset to the page numbers in the `toc.txt` by hand is tedious and error-prone.

This PR solves this problem by checking each line in the `toc.txt` and add the offset when necessary.
The only thing users need to do is adding a comment line (e.g. `//+12` or `//-18`) in the `toc.txt` file.